### PR TITLE
grafana setup

### DIFF
--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -108,3 +108,18 @@
       become: false
       ansible.builtin.command:
         cmd: kubectl apply -f /home/vagrant/.kube/dashboard.yml
+
+    - name: Grafana Installation with Helm
+      kubernetes.core.helm:
+        name: grafana
+        chart_ref: grafana
+        chart_repo_url: https://grafana.github.io/helm-charts
+        release_namespace: grafana
+        create_namespace: true
+      become: false
+
+    #Auto import grafana dashboard
+    - name: Apply Grafana dashboard ConfigMap
+      ansible.builtin.command:
+        cmd: kubectl apply -f ansible/grafana/dashboard-configmap.yaml
+      become: false

--- a/ansible/grafana/README.md
+++ b/ansible/grafana/README.md
@@ -1,0 +1,24 @@
+# Grafana Setup
+This folder explains how to setup the Grafana dashboard to view custom metrics for the application.
+
+## Dashboard Terminology
+This dashboard includes the following metrics:
+- Gauge panel to see the number of requests receieved in `app_requests_total`
+- Time series graphs for: checking the request rate over time `rate(app_requests_total[$interval])` and the average latency `avg(model_latency_seconds)`.
+
+## Content
+- `dashboard.json` Contains and defines the layout of the dashboard
+- `dashboard-confimap.yaml` Contains Kubernetes ConfigMap to install the dashboard
+
+## Importing to UI
+The dashboard can be visualised automatically or manually.
+- Ensure your Kubernetes cluster is running - Grafana will be installed. 
+- Ensure prometheus is installed.
+- If not available already, port forward Grafana using: `kubectl port-forward svc/grafana -n grafana 3000:3000`
+- Open Grafana in browser at: `http://localhost:3000`
+- Upload your `dashboard.json` after hovering over the `+` in the left panel. 
+- Select `Prometheus` as data source and import.
+
+- You can also automatically deploy it via a ConfigMap by applying: 
+```bash
+kubectl apply -f ansible/grafana/dashboard-configmap.yaml

--- a/ansible/grafana/dashboard-configmap.yaml
+++ b/ansible/grafana/dashboard-configmap.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard
+  namespace: grafana
+  labels:
+    grafana_dashboard: "1"
+data:
+  app-dashboard.json: |
+    {
+      "id": null,
+      "title": "App Metrics Dashboard",
+      "timezone": "browser",
+      "schemaVersion": 37,
+      "version": 1,
+      "refresh": "5s",
+      "panels": [
+        {
+          "type": "gauge",
+          "title": "Total Requests",
+          "id": 1,
+          "datasource": "Prometheus",
+          "targets": [
+            {
+              "expr": "app_requests_total",
+              "legendFormat": "requests",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Request Rate",
+          "id": 2,
+          "datasource": "Prometheus",
+          "targets": [
+            {
+              "expr": "rate(app_requests_total[$interval])",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Model Inference Latency",
+          "id": 3,
+          "datasource": "Prometheus",
+          "targets": [
+            {
+              "expr": "avg(model_latency_seconds)",
+              "refId": "A"
+            }
+          ]
+        }
+      ],
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "interval",
+            "type": "interval",
+            "label": "Timeframe",
+            "auto": true,
+            "query": "1m,5m,10m,30m,1h,6h,12h,24h"
+          }
+        ]
+      }
+    }

--- a/ansible/grafana/dashboard/dashboard.json
+++ b/ansible/grafana/dashboard/dashboard.json
@@ -1,0 +1,64 @@
+{
+  "id": null,
+  "title": "App Metrics Dashboard",
+  "tags": ["app", "metrics"],
+  "timezone": "browser",
+  "schemaVersion": 37,
+  "version": 1,
+  "refresh": "5s",
+  "panels": [
+    {
+      "type": "gauge",
+      "title": "Total Requests",
+      "id": 1,
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "app_requests_total",
+          "legendFormat": "requests",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request Rate",
+      "id": 2,
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(app_requests_total[$interval])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Model Inference Latency",
+      "id": 3,
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "avg(model_latency_seconds)",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "interval",
+        "type": "interval",
+        "label": "Timeframe",
+        "auto": true,
+        "query": "1m,5m,15m,1h,6h,12h,1d",
+        "refresh": 2
+      }
+    ]
+  }
+}

--- a/ansible/grafana/tasks/grafana.yml
+++ b/ansible/grafana/tasks/grafana.yml
@@ -1,0 +1,4 @@
+- name: Grafana dashboard ConfigMap
+  ansible.builtin.command:
+    cmd: kubectl apply -f ansible/grafana/dashboard-configmap.yaml
+  become: false


### PR DESCRIPTION
-A basic Grafana dashboard exists that illustrates all app-specific metrics - placeholder
-The dashboard is defined in a JSON file and can be manually imported in the Web UI
-The operations repository contains a README.md that explains the manual installation (if required).
-The dashboard contains specific visualizations for Gauges and Counters.
-The dashboard employs variable timeframe selectors to parameterize the queries.
- The dashboard applies functions (like rate or avg ) to enhance the plots.