### PR TITLE
Implement Traffic Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ helm upgrade --install monitoring prometheus-community/kube-prometheus-stack \
   --namespace monitoring --create-namespace
 ```
 
+## Accessing the Sentiment Analyzer Application
+
+After running the finalization playbook, the Sentiment Analyzer app will be available at:
+
+**URL:** http://app.local
+
+### Prerequisites
+
+1. Add the following to your `/etc/hosts` file:
+
+    ```
+    192.168.56.91 app.local
+    ```
+
 ## Accessing the Kubernetes Dashboard
 
 After running the finalization playbook, the Kubernetes Dashboard will be available at:

--- a/README.md
+++ b/README.md
@@ -55,29 +55,33 @@ ansible-playbook -u vagrant -i 192.168.56.100, ansible/finalization.yml
 ```bash
 kubectl apply -k kubernetes/
 ```
+
 In case of issues, restart minikube.
+
 ```bash
 minikube stop
 minikube start
 ```
 
 2. To set install Helm
-Run the command
+   Run the command
 
 ```bash
 helm install sentiment-analyzer-1 ./helm/sentiment-analyzer/ --set app.ingress.host=app1.local
 ```
 
 To install another instance for the same cluster, be sure the names are changes. For example,
+
 ```bash
 helm install sentiment-analyzer-2 ./helm/sentiment-analyzer/ --set app.ingress.host=app2.local --set model.service.port=5002
 ```
 
 All the requirements are met:
-- [x] Helm chart `Chart.yaml` exists in `helm/sentiment-analyzer/`
-- [x] Covers the deployment (app-service and model-service) using `helm/sentiment-analyzer/templates`
-- [x] Service name can be changed via `helm/sentiment-analyzer/values.yaml`
-- [x] Helm chart can be installed more than once. All resources use the prefic {{ .Release.Name }}
+
+-   [x] Helm chart `Chart.yaml` exists in `helm/sentiment-analyzer/`
+-   [x] Covers the deployment (app-service and model-service) using `helm/sentiment-analyzer/templates`
+-   [x] Service name can be changed via `helm/sentiment-analyzer/values.yaml`
+-   [x] Helm chart can be installed more than once. All resources use the prefic {{ .Release.Name }}
 
 Install Prometheus and Grafana using the following command:
 
@@ -87,7 +91,63 @@ helm repo update
 ```
 
 Create namespace + CRDs + Prometheus/Alertmanager/Grafana:
+
 ```bash
 helm upgrade --install monitoring prometheus-community/kube-prometheus-stack \
   --namespace monitoring --create-namespace
+```
+
+## Accessing the Kubernetes Dashboard
+
+After running the finalization playbook, the Kubernetes Dashboard will be available at:
+
+**URL:** https://dashboard.local
+
+### Prerequisites
+
+1. Add the following to your `/etc/hosts` file:
+
+    ```
+    192.168.56.90 dashboard.local
+    ```
+
+2. Get the authentication token (run on the control node):
+
+    ```bash
+    # SSH into the ctrl VM
+    ssh vagrant@192.168.56.100
+
+    # Get the token
+    kubectl -n kubernetes-dashboard get secret admin-user-token -o jsonpath='{.data.token}' | base64 -d
+    ```
+
+3. Copy the token and use it to log into the dashboard at https://dashboard.local
+
+### Alternative Access Methods
+
+**Port Forward (without ingress):**
+
+```bash
+kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
+```
+
+**Debug service issues:**
+
+```bash
+# Check if dashboard services are running
+kubectl -n kubernetes-dashboard get svc
+
+# Check dashboard pods
+kubectl -n kubernetes-dashboard get pods
+
+# Re-apply dashboard configuration
+kubectl apply -f ansible/k8s/dashboard.yml
+```
+
+Then access via: https://localhost:8443
+
+**Get Token (alternative method):**
+
+```bash
+kubectl -n kubernetes-dashboard create token admin-user
 ```

--- a/ansible/ctrl.yml
+++ b/ansible/ctrl.yml
@@ -17,11 +17,11 @@
         argv:
           - kubeadm
           - init
-          - --apiserver-advertise-address=192.168.56.100 
+          - --apiserver-advertise-address=192.168.56.100
           - --node-name
           - ctrl
-          - --pod-network-cidr=10.244.0.0/16 
-          - --ignore-preflight-errors=NumCPU  # ignore min 2 cpu error
+          - --pod-network-cidr=10.244.0.0/16
+          - --ignore-preflight-errors=NumCPU # ignore min 2 cpu error
         creates: /etc/kubernetes/admin.conf
       when: not admin_conf.stat.exists
       register: kubeadm_init
@@ -33,7 +33,7 @@
         state: directory
         owner: vagrant
         group: vagrant
-        mode: '0755'
+        mode: "0755"
       when: kubeadm_init.changed or not admin_conf.stat.exists
 
     - name: Copy admin.conf to vagrant user's .kube/config
@@ -43,14 +43,14 @@
         remote_src: yes
         owner: vagrant
         group: vagrant
-        mode: '0600'
+        mode: "0600"
       when: kubeadm_init.changed or not admin_conf.stat.exists
 
     - name: Ensure kube directory exists on host
       ansible.builtin.file:
         path: "{{ playbook_dir }}/../kube"
         state: directory
-        mode: '0755'
+        mode: "0755"
       delegate_to: localhost
       become: false
       run_once: true
@@ -79,7 +79,7 @@
         dest: /home/vagrant/kube-flannel.yml
         owner: vagrant
         group: vagrant
-        mode: '0644'
+        mode: "0644"
 
     - name: Modify flannel config to use eth1 interface
       ansible.builtin.replace:
@@ -88,13 +88,12 @@
         replace: '\1- args:\n\2- --ip-masq\n\3- --kube-subnet-mgr\n\3- --iface=eth1'
       register: flannel_modified
 
-
     # Use failed_when instead of ignore_errors to avoid task being marked as failed, when there is non-zero exit
     - name: Check if flannel is already deployed
       ansible.builtin.command:
         cmd: kubectl get namespace kube-flannel
       register: flannel_check
-      failed_when: false 
+      failed_when: false
       changed_when: false
       become: false
       become_user: vagrant
@@ -117,22 +116,22 @@
       ansible.builtin.apt_key:
         url: https://baltocdn.com/helm/signing.asc
         state: present
-      
+
     - name: Install apt-transport-https
       ansible.builtin.apt:
         name: apt-transport-https
         state: present
-      
+
     - name: Add Helm repository
       ansible.builtin.apt_repository:
         repo: "deb https://baltocdn.com/helm/stable/debian/ all main"
         state: present
         filename: helm-stable-debian
-      
+
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: yes
-      
+
     - name: Install Helm
       ansible.builtin.apt:
         name: helm
@@ -149,3 +148,11 @@
       changed_when: helm_diff_plugin.rc == 0
       become: false
       become_user: vagrant
+
+    # Install Python Kubernetes library for Ansible
+    - name: Install Python Kubernetes library
+      ansible.builtin.apt:
+        name:
+          - python3-kubernetes
+          - python3-yaml
+        state: present

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -217,6 +217,33 @@
         state: present
       become: false
 
+    - name: Apply Istio ingress configuration (v1)
+      kubernetes.core.k8s:
+        src: /home/vagrant/k8s/istio-ingress.yml
+        state: present
+        wait: true
+        wait_timeout: 180
+      become: false
+
+    - name: Wait for app deployments to be ready
+      ansible.builtin.command:
+        cmd: kubectl wait --for=condition=Available deployment/app-deployment deployment/model-deployment --timeout=300s
+      become: false
+      retries: 3
+      delay: 10
+
+    - name: Verify Istio sidecar injection
+      ansible.builtin.command:
+        cmd: kubectl get pods -l app=app -o jsonpath='{.items[*].status.containerStatuses[*].name}'
+      register: app_containers
+      become: false
+      changed_when: false
+
+    - name: Display app containers with sidecars
+      ansible.builtin.debug:
+        msg: "App containers: {{ app_containers.stdout }}"
+      become: false
+
     # Step 25: Install Helm Chart for Sentiment Analyzer
     - name: Copy Helm Chart to VM
       ansible.builtin.copy:

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -180,6 +180,30 @@
         cmd: kubectl -n istio-system wait --for=condition=Available deployment --all --timeout=300s
       become: false
 
+    - name: Install Istio Prometheus addon
+      kubernetes.core.k8s:
+        src: /home/vagrant/istio-1.25.2/samples/addons/prometheus.yaml
+        state: present
+      become: false
+
+    - name: Install Istio Jaeger addon
+      kubernetes.core.k8s:
+        src: /home/vagrant/istio-1.25.2/samples/addons/jaeger.yaml
+        state: present
+      become: false
+
+    - name: Install Istio Kiali addon
+      kubernetes.core.k8s:
+        src: /home/vagrant/istio-1.25.2/samples/addons/kiali.yaml
+        state: present
+      become: false
+
+    - name: Wait for Istio addons to be ready
+      ansible.builtin.command:
+        cmd: kubectl -n istio-system wait --for=condition=Available deployment --all --timeout=300s
+      become: false
+      ignore_errors: true
+
     # Step 25: Install Helm Chart for Sentiment Analyzer
     - name: Copy Helm Chart to VM
       ansible.builtin.copy:

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -217,7 +217,7 @@
         state: present
       become: false
 
-    - name: Apply Istio ingress configuration (v1)
+    - name: Apply Istio ingress configuration
       kubernetes.core.k8s:
         src: /home/vagrant/k8s/istio-ingress.yml
         state: present
@@ -225,9 +225,9 @@
         wait_timeout: 180
       become: false
 
-    - name: Wait for app deployments to be ready
+    - name: Wait for app and model deployments to be ready
       ansible.builtin.command:
-        cmd: kubectl wait --for=condition=Available deployment/app-deployment deployment/model-deployment --timeout=300s
+        cmd: kubectl wait --for=condition=Available deployment/app-deployment-v1 deployment/app-deployment-v2 deployment/model-deployment-v1 deployment/model-deployment-v2 --timeout=300s
       become: false
       retries: 3
       delay: 10

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -106,19 +106,19 @@
         create_namespace: true
       become: false
 
-    - name: Copy dashboard.yml to host
-      become: false
+    - name: Copy Kubernetes manifests to VM
       ansible.builtin.copy:
-        src: "{{ playbook_dir }}/k8s/dashboard.yml"
-        dest: /home/vagrant/.kube/dashboard.yml
+        src: "{{ playbook_dir }}/k8s/"
+        dest: /home/vagrant/k8s/
         owner: vagrant
         group: vagrant
         mode: "0644"
+      become: false
 
     - name: Apply dashboard.yml to set up admin user
       become: false
       ansible.builtin.command:
-        cmd: kubectl apply -f /home/vagrant/.kube/dashboard.yml
+        cmd: kubectl apply -f /home/vagrant/k8s/dashboard.yml
 
     # Step 23: Install Istio
     - name: Determine Istio architecture suffix

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -225,12 +225,31 @@
         wait_timeout: 180
       become: false
 
-    - name: Wait for app and model deployments to be ready
-      ansible.builtin.command:
-        cmd: kubectl wait --for=condition=Available deployment/app-deployment-v1 deployment/app-deployment-v2 deployment/model-deployment-v1 deployment/model-deployment-v2 --timeout=300s
+    - name: Wait for app deployments to be ready
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        label_selectors:
+          - app=app
+        wait: true
+        wait_condition:
+          type: Available
+          status: "True"
+        wait_timeout: 300
       become: false
-      retries: 3
-      delay: 10
+
+    - name: Wait for model deployments to be ready
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        label_selectors:
+          - app=model
+        wait: true
+        wait_condition:
+          type: Available
+          status: "True"
+        wait_timeout: 300
+      become: false
 
     - name: Verify Istio sidecar injection
       ansible.builtin.command:

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -90,7 +90,7 @@
             service:
               loadBalancerIP: 192.168.56.90
       become: false
-    
+
     - name: Wait for ingress-nginx webhook
       ansible.builtin.command:
         cmd: kubectl -n ingress-nginx wait --for=condition=Available deployment/ingress-nginx-controller
@@ -120,10 +120,59 @@
       ansible.builtin.command:
         cmd: kubectl apply -f /home/vagrant/.kube/dashboard.yml
 
-    
+    # Step 23: Install Istio
+    - name: Download Istio 1.25.2
+      ansible.builtin.get_url:
+        url: "https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-amd64.tar.gz"
+        dest: /home/vagrant/istio-1.25.2-linux-amd64.tar.gz
+        owner: vagrant
+        group: vagrant
+        mode: "0644"
+
+    - name: Extract Istio
+      ansible.builtin.unarchive:
+        src: /home/vagrant/istio-1.25.2-linux-amd64.tar.gz
+        dest: /home/vagrant
+        remote_src: true
+        owner: vagrant
+        group: vagrant
+
+    - name: Add istioctl to PATH in .bashrc
+      ansible.builtin.lineinfile:
+        path: /home/vagrant/.bashrc
+        line: 'export PATH="$PATH:/home/vagrant/istio-1.25.2/bin"'
+        state: present
+
+    - name: Create IstioOperator configuration for MetalLB
+      ansible.builtin.copy:
+        dest: /home/vagrant/istio-config.yaml
+        # TODO: check if the IP is properly allocated
+        content: |
+          apiVersion: install.istio.io/v1alpha1
+          kind: IstioOperator
+          metadata:
+            name: control-plane
+          spec:
+            values:
+              gateways:
+                istio-ingressgateway:
+                  loadBalancerIP: 192.168.56.91
+        owner: vagrant
+        group: vagrant
+        mode: "0644"
+
+    - name: Install Istio with custom configuration
+      ansible.builtin.command:
+        cmd: istioctl install -y -f /home/vagrant/istio-config.yaml
+      become: false
+
+    - name: Wait for Istio pods to be ready
+      ansible.builtin.command:
+        cmd: kubectl -n istio-system wait --for=condition=Available deployment --all --timeout=300s
+      become: false
 
     # Step 25: Install Helm Chart for Sentiment Analyzer
-    - name: Copy Helm Chart to VM 
+    - name: Copy Helm Chart to VM
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../helm"
         dest: /home/vagrant
@@ -145,8 +194,7 @@
           app:
             ingress:
               host: app.local
-      become: false 
-
+      become: false
 
     - name: Grafana Installation with Helm
       kubernetes.core.helm:
@@ -169,6 +217,5 @@
     #Auto import grafana dashboard
     - name: Apply Grafana dashboard ConfigMap
       ansible.builtin.command:
-        cmd: kubectl apply -f /home/vagrant/dashboard-configmap.yaml  
+        cmd: kubectl apply -f /home/vagrant/dashboard-configmap.yaml
       become: false
-

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -273,41 +273,41 @@
         mode: "0755"
       become: false
 
-    # Step 26:
-    - name: Install Sentiment Analyzer Helm chart
-      kubernetes.core.helm:
-        name: sentiment-analyzer
-        chart_ref: /home/vagrant/helm/sentiment-analyzer
-        release_namespace: default
-        values:
-          model:
-            service:
-              port: 5001
-          app:
-            ingress:
-              host: app.local
-      become: false
+    # # Step 26:
+    # - name: Install Sentiment Analyzer Helm chart
+    #   kubernetes.core.helm:
+    #     name: sentiment-analyzer
+    #     chart_ref: /home/vagrant/helm/sentiment-analyzer
+    #     release_namespace: default
+    #     values:
+    #       model:
+    #         service:
+    #           port: 5001
+    #       app:
+    #         ingress:
+    #           host: app.local
+    #   become: false
 
-    - name: Grafana Installation with Helm
-      kubernetes.core.helm:
-        name: grafana
-        chart_ref: grafana
-        chart_repo_url: https://grafana.github.io/helm-charts
-        release_namespace: grafana
-        create_namespace: true
-      become: false
+    # - name: Grafana Installation with Helm
+    #   kubernetes.core.helm:
+    #     name: grafana
+    #     chart_ref: grafana
+    #     chart_repo_url: https://grafana.github.io/helm-charts
+    #     release_namespace: grafana
+    #     create_namespace: true
+    #   become: false
 
-    - name: Copy Grafana dashboard ConfigMap to VM
-      ansible.builtin.copy:
-        src: "{{ playbook_dir }}/grafana/dashboard-configmap.yaml"
-        dest: /home/vagrant/dashboard-configmap.yaml
-        owner: vagrant
-        group: vagrant
-        mode: "0644"
-      become: false
+    # - name: Copy Grafana dashboard ConfigMap to VM
+    #   ansible.builtin.copy:
+    #     src: "{{ playbook_dir }}/grafana/dashboard-configmap.yaml"
+    #     dest: /home/vagrant/dashboard-configmap.yaml
+    #     owner: vagrant
+    #     group: vagrant
+    #     mode: "0644"
+    #   become: false
 
-    #Auto import grafana dashboard
-    - name: Apply Grafana dashboard ConfigMap
-      ansible.builtin.command:
-        cmd: kubectl apply -f /home/vagrant/dashboard-configmap.yaml
-      become: false
+    # #Auto import grafana dashboard
+    # - name: Apply Grafana dashboard ConfigMap
+    #   ansible.builtin.command:
+    #     cmd: kubectl apply -f /home/vagrant/dashboard-configmap.yaml
+    #   become: false

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -204,6 +204,19 @@
       become: false
       ignore_errors: true
 
+    # Configure Istio for Canary Deployment
+    - name: Enable Istio injection on default namespace
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Namespace
+        name: default
+        definition:
+          metadata:
+            labels:
+              istio-injection: "enabled"
+        state: present
+      become: false
+
     # Step 25: Install Helm Chart for Sentiment Analyzer
     - name: Copy Helm Chart to VM
       ansible.builtin.copy:

--- a/ansible/finalization.yml
+++ b/ansible/finalization.yml
@@ -121,17 +121,26 @@
         cmd: kubectl apply -f /home/vagrant/.kube/dashboard.yml
 
     # Step 23: Install Istio
+    - name: Determine Istio architecture suffix
+      ansible.builtin.set_fact:
+        istio_arch_suffix: "{{ 'amd64' if ansible_facts.architecture == 'x86_64' else 'arm64' if ansible_facts.architecture == 'aarch64' else 'unsupported' }}"
+
+    - name: Fail if architecture is unsupported
+      ansible.builtin.fail:
+        msg: "Unsupported architecture: {{ ansible_facts.architecture }}. Istio download is only configured for x86_64 (amd64) and aarch64 (arm64)."
+      when: istio_arch_suffix == 'unsupported'
+
     - name: Download Istio 1.25.2
       ansible.builtin.get_url:
-        url: "https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-amd64.tar.gz"
-        dest: /home/vagrant/istio-1.25.2-linux-amd64.tar.gz
+        url: "https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-{{ istio_arch_suffix }}.tar.gz"
+        dest: "/home/vagrant/istio-1.25.2-linux-{{ istio_arch_suffix }}.tar.gz"
         owner: vagrant
         group: vagrant
         mode: "0644"
 
     - name: Extract Istio
       ansible.builtin.unarchive:
-        src: /home/vagrant/istio-1.25.2-linux-amd64.tar.gz
+        src: "/home/vagrant/istio-1.25.2-linux-{{ istio_arch_suffix }}.tar.gz"
         dest: /home/vagrant
         remote_src: true
         owner: vagrant
@@ -146,7 +155,6 @@
     - name: Create IstioOperator configuration for MetalLB
       ansible.builtin.copy:
         dest: /home/vagrant/istio-config.yaml
-        # TODO: check if the IP is properly allocated
         content: |
           apiVersion: install.istio.io/v1alpha1
           kind: IstioOperator
@@ -161,9 +169,10 @@
         group: vagrant
         mode: "0644"
 
+    # NOTE: The shell still does not detect istioctl in path
     - name: Install Istio with custom configuration
-      ansible.builtin.command:
-        cmd: istioctl install -y -f /home/vagrant/istio-config.yaml
+      ansible.builtin.shell:
+        cmd: /home/vagrant/istio-1.25.2/bin/istioctl install -y -f /home/vagrant/istio-config.yaml
       become: false
 
     - name: Wait for Istio pods to be ready

--- a/ansible/k8s/dashboard.yml
+++ b/ansible/k8s/dashboard.yml
@@ -13,9 +13,18 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: admin-user
+  - kind: ServiceAccount
+    name: admin-user
+    namespace: kubernetes-dashboard
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-user-token
   namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/service-account.name: admin-user
+type: kubernetes.io/service-account-token
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -28,13 +37,13 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: dashboard.local
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: kubernetes-dashboard-web
-            port:
-              number: 443
+    - host: dashboard.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kubernetes-dashboard-kong-proxy
+                port:
+                  number: 443

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -256,6 +256,12 @@ spec:
       route:
         - destination:
             host: app
+            subset: v1
+          weight: 90
+        - destination:
+            host: app
+            subset: v2
+          weight: 10
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
@@ -290,3 +296,18 @@ spec:
         - destination:
             host: model
             subset: v1
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: app-dr
+  namespace: default
+spec:
+  host: app
+  subsets:
+    - name: v1
+      labels:
+        version: v1
+    - name: v2
+      labels:
+        version: v2

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: model
         version: v1
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "5001"
     spec:
       containers:
         - name: model-service
@@ -72,6 +76,10 @@ spec:
       labels:
         app: app
         version: v1
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
     spec:
       containers:
         - name: app-service
@@ -116,6 +124,10 @@ spec:
       labels:
         app: model
         version: v2
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "5001"
     spec:
       containers:
         - name: model-service
@@ -171,6 +183,10 @@ spec:
       labels:
         app: app
         version: v2
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
     spec:
       containers:
         - name: app-service

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -304,6 +304,10 @@ metadata:
   namespace: default
 spec:
   host: app
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        useSourceIp: true
   subsets:
     - name: v1
       labels:

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -256,3 +256,35 @@ spec:
       route:
         - destination:
             host: app
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: model-dr
+spec:
+  host: model
+  subsets:
+    - name: v1
+      labels: { version: v1 }
+    - name: v2
+      labels: { version: v2 }
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: model-vs
+spec:
+  hosts:
+    - model
+  http:
+    - match:
+        - sourceLabels:
+            version: v2
+          route:
+            - destination:
+                host: model
+                subset: v2
+        - route:
+            - destination:
+                host: lib
+                subset: v1

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -261,6 +261,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: model-dr
+  namespace: default
 spec:
   host: model
   subsets:
@@ -273,6 +274,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: model-vs
+  namespace: default
 spec:
   hosts:
     - model

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -282,11 +282,11 @@ spec:
     - match:
         - sourceLabels:
             version: v2
-          route:
-            - destination:
-                host: model
-                subset: v2
-        - route:
-            - destination:
-                host: lib
-                subset: v1
+      route:
+        - destination:
+            host: model
+            subset: v2
+    - route:
+        - destination:
+            host: model
+            subset: v1

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -1,8 +1,8 @@
-# istio-ingress.yml - Main v1 deployment with Istio
+# istio-ingress.yml - canary release deployment with Istio
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: model-deployment
+  name: model-deployment-v1
   namespace: default
   labels:
     app: model
@@ -20,43 +20,43 @@ spec:
         version: v1
     spec:
       containers:
-      - name: model-service
-        image: ghcr.io/remla2025-team19/model-service:0.0.5
-        ports:
-        - containerPort: 5001
-        env:
-        - name: MODEL_VERSION
-          value: "1.0.11"
-        - name: MODEL_SERVICE_PORT
-          value: "5001"
-        - name: MODEL_SERVICE_HOST
-          value: "0.0.0.0"
-        - name: MODEL_ARTIFACT_URL
-          value: "https://github.com/remla2025-team19/model-training/releases/download/v1.0.11/sentiment_model_v1.0.11.pkl"
-        - name: PREDICTION_THRESHOLD
-          value: "0.75"
-        - name: MODEL_CACHE_DIR
-          value: "/models_cache"
-        volumeMounts:
-        - name: model-cache-volume
-          mountPath: /models_cache
-        resources:
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
+        - name: model-service
+          image: ghcr.io/remla2025-team19/model-service:0.0.5
+          ports:
+            - containerPort: 5001
+          env:
+            - name: MODEL_VERSION
+              value: "1.0.11"
+            - name: MODEL_SERVICE_PORT
+              value: "5001"
+            - name: MODEL_SERVICE_HOST
+              value: "0.0.0.0"
+            - name: MODEL_ARTIFACT_URL
+              value: "https://github.com/remla2025-team19/model-training/releases/download/v1.0.11/sentiment_model_v1.0.11.pkl"
+            - name: PREDICTION_THRESHOLD
+              value: "0.75"
+            - name: MODEL_CACHE_DIR
+              value: "/models_cache"
+          volumeMounts:
+            - name: model-cache-volume
+              mountPath: /models_cache
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
       volumes:
-      - name: model-cache-volume
-        hostPath:
-          path: /mnt/shared/model_cache
-          type: DirectoryOrCreate
+        - name: model-cache-volume
+          hostPath:
+            path: /mnt/shared/model_cache
+            type: DirectoryOrCreate
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: app-deployment
+  name: app-deployment-v1
   namespace: default
   labels:
     app: app
@@ -74,28 +74,128 @@ spec:
         version: v1
     spec:
       containers:
-      - name: app-service
-        image: ghcr.io/remla2025-team19/app-service:0.0.14
-        ports:
-        - containerPort: 8080
-        env:
-        - name: MODEL_SERVICE_URL
-          value: "http://model:5001"
-        - name: APP_LOG_LEVEL
-          value: "info"
-        - name: APP_API_KEY
-          value: "sk-v1-kjdflkaflsdaiuyhcouwiheourh"
-        - name: APP_DB_USER
-          value: "admin"
-        - name: APP_DB_PASSWORD
-          value: "password"
-        resources:
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
+        - name: app-service
+          image: ghcr.io/remla2025-team19/app-service:0.0.14
+          ports:
+            - containerPort: 8080
+          env:
+            - name: MODEL_SERVICE_URL
+              value: "http://model:5001"
+            - name: APP_LOG_LEVEL
+              value: "info"
+            - name: APP_API_KEY
+              value: "sk-v1-kjdflkaflsdaiuyhcouwiheourh"
+            - name: APP_DB_USER
+              value: "admin"
+            - name: APP_DB_PASSWORD
+              value: "password"
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-deployment-v2
+  namespace: default
+  labels:
+    app: model
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: model
+        version: v2
+    spec:
+      containers:
+        - name: model-service
+          #TODO: set this to a different version tag after creating a prerelease app version
+          image: ghcr.io/remla2025-team19/model-service:latest
+          ports:
+            - containerPort: 5001
+          env:
+            - name: MODEL_VERSION
+              value: "1.0.11"
+            - name: MODEL_SERVICE_PORT
+              value: "5001"
+            - name: MODEL_SERVICE_HOST
+              value: "0.0.0.0"
+            - name: MODEL_ARTIFACT_URL
+              value: "https://github.com/remla2025-team19/model-training/releases/download/v1.0.11/sentiment_model_v1.0.11.pkl"
+            - name: PREDICTION_THRESHOLD
+              value: "0.75"
+            - name: MODEL_CACHE_DIR
+              value: "/models_cache"
+          volumeMounts:
+            - name: model-cache-volume
+              mountPath: /models_cache
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+      volumes:
+        - name: model-cache-volume
+          hostPath:
+            path: /mnt/shared/model_cache
+            type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment-v2
+  namespace: default
+  labels:
+    app: app
+    version: v2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: app
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: app
+        version: v2
+    spec:
+      containers:
+        - name: app-service
+          #TODO: set this to a different version tag after creating a prerelease app version
+          image: ghcr.io/remla2025-team19/app-service:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: MODEL_SERVICE_URL
+              value: "http://model:5001"
+            - name: APP_LOG_LEVEL
+              value: "info"
+            - name: APP_API_KEY
+              value: "sk-v1-kjdflkaflsdaiuyhcouwiheourh"
+            - name: APP_DB_USER
+              value: "admin"
+            - name: APP_DB_PASSWORD
+              value: "password"
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
 ---
 apiVersion: v1
 kind: Service
@@ -106,9 +206,9 @@ spec:
   selector:
     app: model
   ports:
-  - name: http
-    port: 5001
-    targetPort: 5001
+    - name: http
+      port: 5001
+      targetPort: 5001
 ---
 apiVersion: v1
 kind: Service
@@ -119,9 +219,9 @@ spec:
   selector:
     app: app
   ports:
-  - name: http
-    port: 80
-    targetPort: 8080
+    - name: http
+      port: 80
+      targetPort: 8080
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
@@ -132,12 +232,12 @@ spec:
   selector:
     istio: ingressgateway
   servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "app.local"
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "app.local"
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
@@ -146,13 +246,13 @@ metadata:
   namespace: default
 spec:
   gateways:
-  - sentiment-gateway
+    - sentiment-gateway
   hosts:
-  - "app.local"
+    - "app.local"
   http:
-  - match:
-    - uri:
-        prefix: /
-    route:
-    - destination:
-        host: app
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: app

--- a/ansible/k8s/istio-ingress.yml
+++ b/ansible/k8s/istio-ingress.yml
@@ -1,0 +1,158 @@
+# istio-ingress.yml - Main v1 deployment with Istio
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-deployment
+  namespace: default
+  labels:
+    app: model
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: model
+        version: v1
+    spec:
+      containers:
+      - name: model-service
+        image: ghcr.io/remla2025-team19/model-service:0.0.5
+        ports:
+        - containerPort: 5001
+        env:
+        - name: MODEL_VERSION
+          value: "1.0.11"
+        - name: MODEL_SERVICE_PORT
+          value: "5001"
+        - name: MODEL_SERVICE_HOST
+          value: "0.0.0.0"
+        - name: MODEL_ARTIFACT_URL
+          value: "https://github.com/remla2025-team19/model-training/releases/download/v1.0.11/sentiment_model_v1.0.11.pkl"
+        - name: PREDICTION_THRESHOLD
+          value: "0.75"
+        - name: MODEL_CACHE_DIR
+          value: "/models_cache"
+        volumeMounts:
+        - name: model-cache-volume
+          mountPath: /models_cache
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+      volumes:
+      - name: model-cache-volume
+        hostPath:
+          path: /mnt/shared/model_cache
+          type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+  namespace: default
+  labels:
+    app: app
+    version: v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: app
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: app
+        version: v1
+    spec:
+      containers:
+      - name: app-service
+        image: ghcr.io/remla2025-team19/app-service:0.0.14
+        ports:
+        - containerPort: 8080
+        env:
+        - name: MODEL_SERVICE_URL
+          value: "http://model:5001"
+        - name: APP_LOG_LEVEL
+          value: "info"
+        - name: APP_API_KEY
+          value: "sk-v1-kjdflkaflsdaiuyhcouwiheourh"
+        - name: APP_DB_USER
+          value: "admin"
+        - name: APP_DB_PASSWORD
+          value: "password"
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model
+  namespace: default
+spec:
+  selector:
+    app: model
+  ports:
+  - name: http
+    port: 5001
+    targetPort: 5001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+  namespace: default
+spec:
+  selector:
+    app: app
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: sentiment-gateway
+  namespace: default
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "app.local"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: sentiment-virtual-service
+  namespace: default
+spec:
+  gateways:
+  - sentiment-gateway
+  hosts:
+  - "app.local"
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: app

--- a/kubernetes/app.yaml
+++ b/kubernetes/app.yaml
@@ -18,7 +18,7 @@ spec:
         - name: app-service
           image: ghcr.io/remla2025-team19/app-service:0.0.14
           ports:
-            - containerPort: 8000
+            - containerPort: 8080
           env:
             - name: MODEL_SERVICE_URL
               valueFrom:
@@ -67,7 +67,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8000
+      targetPort: 8080
   type: ClusterIP
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
This fixes the kubernetes dashboard config and follows the in-class exercise to set up a canary release with Istio:
1. Install istio
  - [x] install the k8s ansible module (make sure to reprovision ctrl)
  - [x] step 23 from A2, which we need for A5.
  - [x] install istio addons: 
    - [x] prometheus
    - [x] jaeger
    - [x] kiali
  
  You can test the addons with:
  > vagrant@ctrl: istioctl dashboard prometheus --address 0.0.0.0.0
  http://0.0.0.0:9090
  > vagrant@ctrl: istioctl dashboard kiali --address 0.0.0.0
  http://0.0.0.0:20001/kiali

2. Enable istio and deploy
  - ~deploy simple pod~ (not needed)
  - [x] enable istio injection on default namespace

3. Configure gateway
  - [x] create ~pods~ deployments and services
    > I assume we want to reuse the helm installation for this. For now I will just create a new deployment in istio-ingress following the exercise.
  - [x] create a gateway
  - [x] define a virtualservice

4. Custom Routing
  - [x] create canary deployments
  - [x] define DestinationRule 
  - [x] add VirtualService for consistent versions
  - [x] configure Canary release
  - [x] configure sticky sessions on ip

5. Metrics
  - [x] configure prometheus metrics

## Traffic Management Requirements
- [x] deploys and is accessible
### Sufficient 
- [x] The project resembles the state of the in-class exercise.
- [x] The app defines a Gateway and VirtualServices.
- [x] The application is accessible through the IngressGateway (i.e., minikube tunnel ).
### Good 
- [x] It uses DestinationRules and weights to enable a 90/10 routing of the app service.
- [x] The versions of model-service and app are consistent.
### Excellent 
- [x] The project implements Sticky Sessions, i.e., requests from the same origin have a stable routing
